### PR TITLE
Updated kotlin blog deployment spec to load configmap and secrets via k8s into spring boot

### DIFF
--- a/k8s/blog-deployment.yaml
+++ b/k8s/blog-deployment.yaml
@@ -15,16 +15,19 @@ spec:
     spec:
       containers:
       - env:
+        - name: SPRING_CONFIG_ADDITIONAL-LOCATION
+          value: "file:./secrets/"
         - name: DB_CONNECTION_STRING
           value: mysql://db.default:$(DB_SERVICE_PORT)/dbname?autoReconnect=true&useSSL=false
-        - name: DB_PASS
-          value: dbpass # These are bad credentials we'll eventually want to migrate to using secrets (also avoid needing to keep this in sync with the DB deployment spec)
-        - name: DB_USER
-          value: dbuser
-        - name: SPRING_PROFILES_ACTIVE
-          value: mysql
         image: kiva/kiosa-dev:latest #We'll eventually want to be smarter with our tagging and not rely on latest
         name: blog
+        volumeMounts:
+        - name: blog-config
+          mountPath: "/root/config" # needs to be under /root, this automatically searched by spring boot
+          readOnly: true
+        - name: blog-secrets
+          mountPath: "/root/secrets" # this is configured via env variable above
+          readOnly: true
         ports:
         - containerPort: 8080
         resources: {}
@@ -43,4 +46,17 @@ spec:
       imagePullSecrets:
         - name: regcred # This will only work if you have set up a regcred secret containing Docker Hub credentials
       restartPolicy: Always
+      volumes:
+      - name: blog-config
+        configMap:
+          name: blog-config # kubectl create configmap blog-config --from-file=configs/blog.properties
+          items:
+          - key: blog.properties
+            path: application.properties # filename spring boot will look for
+      - name: blog-secrets
+        secret:
+          secretName: blog-secrets # kubectl create secret generic blog-secrets --from-file=secrets/blog.secrets.properties
+          items:
+          - key: blog.secrets.properties
+            path: application.properties # filename spring boot will look for
 status: {}

--- a/k8s/blog-deployment.yaml
+++ b/k8s/blog-deployment.yaml
@@ -17,8 +17,6 @@ spec:
       - env:
         - name: SPRING_CONFIG_ADDITIONAL-LOCATION
           value: "file:./secrets/"
-        - name: DB_CONNECTION_STRING
-          value: mysql://db.default:$(DB_SERVICE_PORT)/dbname?autoReconnect=true&useSSL=false
         image: kiva/kiosa-dev:latest #We'll eventually want to be smarter with our tagging and not rely on latest
         name: blog
         volumeMounts:

--- a/k8s/configs/blog.properties
+++ b/k8s/configs/blog.properties
@@ -1,0 +1,2 @@
+spring.jpa.hibernate.ddl-auto=create-drop
+spring.datasource.url=jdbc:mysql://db.default:${DB_SERVICE_PORT}/dbname?autoReconnect=true&useSSL=false

--- a/k8s/secrets/blog.secrets.properties
+++ b/k8s/secrets/blog.secrets.properties
@@ -1,0 +1,2 @@
+spring.datasource.username=dbuser
+spring.datasource.password=dbpass


### PR DESCRIPTION
No update to the kotlin-demo (kiosa-dev) image is needed!

This does not solve the problem of how the configmaps / secrets are loaded into k8s, only how we can set up our deployments by mounting the said resources as volumes that will get loaded by spring boot.

You could actually imagine the configs existing in some repo that we keep in sync, but there may be other delivery mechanisms. I know tools like Hashicorp Vault exist for secrets management, but I am not sure whether we need something that extensive right now.

In any event, I wanted to share this as a path for getting config / secret data into spring boot apps once the resources are created in k8s!