### PR TITLE
CASH-240: Kubernetes specs for single node rabbitmq and recon service as cron job

### DIFF
--- a/k8s/recon/rabbitmq-single-node.yaml
+++ b/k8s/recon/rabbitmq-single-node.yaml
@@ -1,0 +1,36 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: rabbitmq-deployment
+spec:
+  selector:
+    matchLabels:
+      app: rabbitmq
+  replicas: 1
+  strategy: {}
+  template:
+    metadata:
+      labels:
+        app: rabbitmq
+    spec:
+      containers:
+      - name: rabbitmq
+        image: rabbitmq:management
+        resources: {}
+      restartPolicy: Always
+status: {}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: rabbitmq
+spec:
+  selector:
+    app: rabbitmq
+  type: ClusterIP
+  ports:
+  - name: broker
+    port: 5672
+    targetPort: 5672
+status:
+  loadBalancer: {}

--- a/k8s/recon/recon.yaml
+++ b/k8s/recon/recon.yaml
@@ -1,43 +1,21 @@
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: recon-deployment
-spec:
-  selector:
-    matchLabels:
-      app: recon
-  replicas: 1
-  strategy: {}
-  template:
-    metadata:
-      labels:
-        app: recon
-    spec:
-      containers:
-      - name: recon
-        image: kiva/recon:master-2
-        env:
-        - name: SPRING_RABBITMQ_HOST
-          value: rabbitmq.default
-        - name: SPRING_RABBITMQ_PORT
-          value: $(RABBITMQ_SERVICE_PORT)
-        resources: {}
-      imagePullSecrets:
-      - name: regcred
-      restartPolicy: Always
-status: {}
----
-apiVersion: v1
-kind: Service
+apiVersion: batch/v1beta1
+kind: CronJob
 metadata:
   name: recon
 spec:
-  selector:
-    app: recon
-  type: ClusterIP
-  ports:
-  - name: recon
-    port: 8080
-    targetPort: 8080
-status:
-  loadBalancer: {}
+  schedule: "*/1 * * * *" # Every minute for local dev convenience, in actual dev this can be far, far less frequent
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+          - name: recon
+            image: kiva/recon:master-3
+            env:
+            - name: SPRING_RABBITMQ_HOST
+              value: rabbitmq.default # Specific to spec in rabbitmq-single-node.yaml. Host and port should be adapted to actual Dev specs for RabbitMQ.
+            - name: SPRING_RABBITMQ_PORT
+              value: $(RABBITMQ_SERVICE_PORT)
+          imagePullSecrets:
+          - name: regcred # Very specific to local Docker credentials setup
+          restartPolicy: OnFailure

--- a/k8s/recon/recon.yaml
+++ b/k8s/recon/recon.yaml
@@ -1,0 +1,43 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: recon-deployment
+spec:
+  selector:
+    matchLabels:
+      app: recon
+  replicas: 1
+  strategy: {}
+  template:
+    metadata:
+      labels:
+        app: recon
+    spec:
+      containers:
+      - name: recon
+        image: kiva/recon:master-2
+        env:
+        - name: SPRING_RABBITMQ_HOST
+          value: rabbitmq.default
+        - name: SPRING_RABBITMQ_PORT
+          value: $(RABBITMQ_SERVICE_PORT)
+        resources: {}
+      imagePullSecrets:
+      - name: regcred
+      restartPolicy: Always
+status: {}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: recon
+spec:
+  selector:
+    app: recon
+  type: ClusterIP
+  ports:
+  - name: recon
+    port: 8080
+    targetPort: 8080
+status:
+  loadBalancer: {}


### PR DESCRIPTION
@N1kw: For review & verification.

FYI @jmallatt-kiva: This is a single node rabbitmq deployment + service, plus the recon service as a cronjob that runs every minute. I've tried to comment / point out the parts of the recon spec that might need to be adapted: host/port depending on the actual Dev situation with rabbitmq, whatever credentials secret is set up in Dev for Docker Hub, and cron string adjustment to something probably less frequent (1/hour, every 15 minutes...?).

Let me know if there are any questions!